### PR TITLE
fix: correct default installation path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ AC_PATH_PROG([IBUS_TABLE_CREATEDB],[ibus-table-createdb],
         [AC_MSG_ERROR([ibus-table-createdb not found.])])
 AS_IF([$IBUS_TABLE_CREATEDB --help >/dev/null 2>&1],[],
         [AC_MSG_ERROR([Failed to execute $IBUS_TABLE_CREATEDB.])])
+AC_PREFIX_DEFAULT([/usr])
 
 # OUTPUT files
 AC_CONFIG_FILES(Makefile


### PR DESCRIPTION
According to the [source code of ibus-table](https://github.com/kaio/ibus-table/blob/main/tools/ibus-table-query#L29), fix the default installations paths of this input method by removing `local/` as follows.
1. `/usr/local/share/ibus-table/tables` → `/usr/share/ibus-table/tables`
2. `/usr/local/share/ibus-table/icons` → `/usr/share/ibus-table/icons`